### PR TITLE
Remove dead code, split business logic from CLI parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,5 +11,7 @@ libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "3.3.0",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+  "joda-time" % "joda-time" % "2.8.1",
+  "org.joda" % "joda-convert" % "1.8",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )

--- a/src/main/scala/com/gu/certificate/AwsEncryption.scala
+++ b/src/main/scala/com/gu/certificate/AwsEncryption.scala
@@ -1,13 +1,13 @@
 package com.gu.certificate
 
-import java.nio.{CharBuffer, ByteBuffer}
 import java.nio.charset.Charset
+import java.nio.{ByteBuffer, CharBuffer}
 
-import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.regions.{Regions, Region}
+import com.amazonaws.regions.Region
 import com.amazonaws.services.kms.AWSKMSClient
 import com.amazonaws.services.kms.model._
+
 import scala.collection.JavaConverters._
 
 class AwsEncryption(region: Region, provider: AWSCredentialsProvider) {
@@ -64,5 +64,4 @@ class AwsEncryption(region: Region, provider: AWSCredentialsProvider) {
     val result = client.describeKey(request)
     result.getKeyMetadata
   }
-
 }

--- a/src/main/scala/com/gu/certificate/FileHelpers.scala
+++ b/src/main/scala/com/gu/certificate/FileHelpers.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.ByteBuffer
 
 import scalax.file.Path
+import scalax.file.defaultfs.DefaultPath
 
 trait FileHelpers {
   lazy val homeDir = Option(System.getProperty("user.home"))

--- a/src/main/scala/com/gu/certificate/Magic.scala
+++ b/src/main/scala/com/gu/certificate/Magic.scala
@@ -3,71 +3,113 @@ package com.gu.certificate
 import java.io.File
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth._
+import com.amazonaws.auth.{AWSCredentialsProvider, STSAssumeRoleSessionCredentialsProvider, _}
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
-import com.amazonaws.services.identitymanagement.model._
+import com.amazonaws.services.identitymanagement.model.UploadServerCertificateRequest
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.util.Try
 import scalax.io.Resource
 
-object Magic extends App with BouncyCastle with FileHelpers {
-  case class Config(mode:String="", domain:String="", awsProfile:Option[String]=None, certificate:Option[File]=None, chain:Option[File]=None, force:Boolean=false, awsRegion:Option[String]=None)
 
-  val parser = new scopt.OptionParser[Config]("magic") {
-    head("certificate magic", "1.0")
-    opt[String]('p', "profile") optional() action { (x, c) => c.copy(awsProfile = Some(x)) }
-    opt[String]('r', "region") optional() action { (x, c) => c.copy(awsRegion = Some(x)) }
-    cmd("create") action { (_, c) =>
-      c.copy(mode = "create") } text "create a new keypair and certificate signing request (CSR)" children(
-        opt[String]('d', "domain") required() action { (x, c) => c.copy(domain = x) },
-        opt[Unit]('f', "force") optional() action { (_, c) => c.copy(force = true) }
-      )
-    cmd("install") action { (_, c) =>
-      c.copy(mode = "install") } text "install a certificate" children(
-      opt[File]("certificate") required() action { (x, c) =>
-        c.copy(certificate = Some(x)) } text "provided certificate",
-      opt[File]("chain") optional() action { (x, c) =>
-        c.copy(chain = Some(x)) } text "provided certificate chain (will try to build it if not provided)"
-      )
-    cmd("list") action { (_, c) => c.copy(mode = "list") }
-  }
+object Magic extends BouncyCastle with FileHelpers {
 
-  def safeDomainString(domain: String): String = domain.replace("*", "star")
+  def create(domain: String, awsProfile: Option[String], force: Boolean, regionNameOpt: Option[String]): Unit = {
+    val region = getRegion(regionNameOpt)
+    val safeDomain = safeDomainString(domain)
+    val credentialsProvider = getCredentialsProvider(awsProfile)
 
-  def withTempCredentials[T](region: Region, policyArn: String)(block: AWSCredentialsProvider => T) = {
-    val iamClient = region.createClient(classOf[AmazonIdentityManagementClient], null, null)
-
-    // create credentials
-    val dateTime = ISODateTimeFormat.basicDateTimeNoMillis().print(new DateTime())
-    val userName = s"certificate-magic-$dateTime"
-    iamClient.createUser(new CreateUserRequest().withUserName(userName))
-
-    try {
-      iamClient.attachUserPolicy(new AttachUserPolicyRequest().withUserName(userName).withPolicyArn(policyArn))
-      val accessKeyResult = iamClient.createAccessKey(new CreateAccessKeyRequest().withUserName(userName))
-
-      // create provider
-      val provider:AWSCredentialsProvider =
-        new AWSCredentialsProvider {
-          def refresh() {}
-          val getCredentials: AWSCredentials = new BasicAWSCredentials(
-            accessKeyResult.getAccessKey.getAccessKeyId,
-            accessKeyResult.getAccessKey.getSecretAccessKey
-          )
-        }
-
-      // run code
-      block(provider)
-    } finally {
-      // delete credentials
-      iamClient.deleteUser(new DeleteUserRequest().withUserName(userName))
+    // check if private key already exists
+    if (!force) {
+      val encryptedKey = getFile(safeDomain, "pkenc")
+      if (encryptedKey.exists) throw new RuntimeException(s"Private key already exists at $encryptedKey, use --force to overwrite if you are sure you no longer need this private key")
     }
+
+    // create keypair
+    val keyPair = createKeyPair()
+    val pkPem = toPem(keyPair.getPrivate)
+
+    // encrypt private key with KMS
+    val cryptProvider = new AwsEncryption(region, credentialsProvider)
+    val keyId = cryptProvider.getCertificateMagicKey
+    val ciphertext = cryptProvider.encrypt(keyId, pkPem, domain)
+    val pkEncFile = saveFile(ciphertext, safeDomain, "pkenc")
+
+    // create CSR
+    val csrPem = toPem(createCsr(keyPair, domain))
+    // display/save CSR
+    val csrFile = saveFile(csrPem, safeDomain, "csr")
+
+    // give details to user
+    println(csrPem)
+    System.err.println(s"Written encrypted PK to $pkEncFile and CSR to $csrFile")
   }
 
-  def assumeRole[T](region: Region, roleArn: String)(block: AWSCredentialsProvider => T) = {
+  def install(awsProfile: Option[String], certificateFile: File, chainFile: Option[File], regionNameOpt: Option[String]): Unit = {
+    val region = getRegion(regionNameOpt)
+    val credentialsProvider = getCredentialsProvider(awsProfile)
+
+    // read in and inspect certificate
+    val certificatePem = Resource.fromFile(certificateFile).string
+    val certificate = readCertificate(certificatePem).getOrElse {
+      throw new RuntimeException(s"Couldn't read certificate at $certificateFile")
+    }
+    val domain = getCommonName(certificate)
+    val safeDomain = safeDomainString(domain)
+    val expDate = ISODateTimeFormat.date().print(new DateTime(certificate.getNotAfter))
+
+    // find and decrypt private key
+    val readPkEncFile = Try(readBytes(safeDomain, "pkenc")).getOrElse {
+      throw new RuntimeException(s"Couldn't find encrypted private key for $domain")
+    }
+    val cryptProvider = new AwsEncryption(region, credentialsProvider)
+    val decryptedPem = cryptProvider.decrypt(readPkEncFile, domain)
+
+    // check certificate matches keypair
+    val keypair = readKeyPair(decryptedPem).getOrElse(throw new RuntimeException(s"Couldn't read decrypted private key"))
+    val keyPairPublicKey = keypair.getPublicKeyInfo.getPublicKeyData.getBytes.toList
+    val certPublicKey = certificate.getSubjectPublicKeyInfo.getPublicKeyData.getBytes.toList
+    assert(
+      keyPairPublicKey == certPublicKey,
+      s"Invalid certificate: Public key in certificate and public key in stored keypair do not match"
+    )
+
+    System.err.println(s"decrypted: $decryptedPem")
+
+    // load or build chain
+    val chainPem: String = chainFile.map { file =>
+      Resource.fromFile(file).string
+    }.getOrElse {
+      getChainFromCertificate(certificate).map(toPem(_).trim).mkString("\n")
+    }
+
+    // upload to AWS
+    assumeRole("arn:aws:iam::aws:policy/IAMFullAccess") { provider =>
+      val iamClient = region.createClient(classOf[AmazonIdentityManagementClient], provider, null)
+      iamClient.uploadServerCertificate(
+        new UploadServerCertificateRequest()
+          .withServerCertificateName(s"$safeDomain-exp$expDate")
+          .withPrivateKey(decryptedPem)
+          .withCertificateBody(certificatePem)
+          .withCertificateChain(chainPem)
+      )
+    }
+
+    // TODO: [optionally?] delete the associated files so the private key is no longer around
+  }
+
+  def list(): Unit = {
+    System.err.println("Currently created keys")
+    // TODO: Read in subject from CSR and print in a more friendly format
+    println(listFiles("csr").toSet)
+    println(listFiles("pkenc").toSet)
+  }
+
+  private def safeDomainString(domain: String) = domain.replace("*", "star")
+
+  private def assumeRole[T](roleArn: String)(block: AWSCredentialsProvider => T): T = {
     val dateTime = ISODateTimeFormat.basicDateTimeNoMillis().print(new DateTime())
     val userName = s"certificate-magic-$dateTime"
 
@@ -76,101 +118,18 @@ object Magic extends App with BouncyCastle with FileHelpers {
     block(provider)
   }
 
-  parser.parse(args, Config()) foreach { config =>
-    lazy val region = Region.getRegion(
-      config.awsRegion
+  private def getCredentialsProvider(awsProfile: Option[String]): AWSCredentialsProvider = {
+    awsProfile.map { profile =>
+      new ProfileCredentialsProvider(profile)
+    }.getOrElse(new DefaultAWSCredentialsProviderChain())
+  }
+
+  private def getRegion(regionNameOpt: Option[String]): Region = {
+    Region.getRegion(
+      regionNameOpt
         .orElse(Option(System.getenv("AWS_DEFAULT_REGION")))
         .map(Regions.fromName)
         .getOrElse(Regions.EU_WEST_1)
     )
-
-    lazy val provider = config.awsProfile.map { profile =>
-      new ProfileCredentialsProvider(profile)
-    }.getOrElse(new DefaultAWSCredentialsProviderChain())
-
-    lazy val cryptProvider = new AwsEncryption(region, provider)
-
-    config match {
-      case Config("create", domain, profile, _, _, force, _) =>
-        val safeDomain = safeDomainString(domain)
-        // check if private key already exists
-        if (!force) {
-          val encryptedKey = getFile(safeDomain, "pkenc")
-          if (encryptedKey.exists) throw new RuntimeException(s"Private key already exists at $encryptedKey, use --force to overwrite if you are sure you no longer need this private key")
-        }
-
-        // create keypair
-        val keyPair = createKeyPair()
-        val pkPem = toPem(keyPair.getPrivate)
-
-        // encrypt private key with KMS
-        val keyId = cryptProvider.getCertificateMagicKey
-        val ciphertext = cryptProvider.encrypt(keyId, pkPem, domain)
-        val pkEncFile = saveFile(ciphertext, safeDomain, "pkenc")
-
-        // create CSR
-        val csrPem = toPem(createCsr(keyPair, domain))
-        // display/save CSR
-        val csrFile = saveFile(csrPem, safeDomain, "csr")
-
-        // give details to user
-        println(csrPem)
-        System.err.println(s"Written encrypted PK to $pkEncFile and CSR to $csrFile")
-
-      case Config("install", _, _, Some(certificateFile), chainFile, _, _) =>
-        // read in and inspect certificate
-        val certificatePem = Resource.fromFile(certificateFile).string
-        val certificate = readCertificate(certificatePem).getOrElse {
-          throw new RuntimeException(s"Couldn't read certificate at $certificateFile")
-        }
-        val domain = getCommonName(certificate)
-        val safeDomain = safeDomainString(domain)
-        val expDate = ISODateTimeFormat.date().print(new DateTime(certificate.getNotAfter))
-
-        // find and decrypt private key
-        val readPkEncFile = Try(readBytes(safeDomain, "pkenc")).getOrElse {
-          throw new RuntimeException(s"Couldn't find encrypted private key for $domain")
-        }
-        val decryptedPem = cryptProvider.decrypt(readPkEncFile, domain)
-
-        // check certificate matches keypair
-        val keypair = readKeyPair(decryptedPem).getOrElse(throw new RuntimeException(s"Couldn't read decrypted private key"))
-        val keyPairPublicKey = keypair.getPublicKeyInfo.getPublicKeyData.getBytes.toList
-        val certPublicKey = certificate.getSubjectPublicKeyInfo.getPublicKeyData.getBytes.toList
-        assert(
-          keyPairPublicKey == certPublicKey,
-          s"Invalid certificate: Public key in certificate and public key in stored keypair do not match"
-        )
-
-        System.err.println(s"decrypted: $decryptedPem")
-
-        // load or build chain
-        val chainPem: String = chainFile.map { file =>
-          Resource.fromFile(file).string
-        }.getOrElse {
-          getChainFromCertificate(certificate).map(toPem(_).trim).mkString("\n")
-        }
-
-        println(chainPem)
-
-        // upload to AWS
-        val iamClient = region.createClient(classOf[AmazonIdentityManagementClient], provider, null)
-        iamClient.uploadServerCertificate(
-          new UploadServerCertificateRequest()
-            .withServerCertificateName(s"$safeDomain-exp$expDate")
-            .withPrivateKey(decryptedPem)
-            .withCertificateBody(certificatePem)
-            .withCertificateChain(chainPem)
-        )
-
-        // TODO: [optionally?] delete the associated files so the private key is no longer around
-
-      case Config("list", _, _, _, _, _, _) =>
-
-        System.err.println("Currently created keys")
-        // TODO: Read in subject form CSR and print in a more friendly format
-        println(listFiles("csr").toSet)
-        println(listFiles("pkenc").toSet)
-    }
   }
 }

--- a/src/main/scala/com/gu/certificate/Main.scala
+++ b/src/main/scala/com/gu/certificate/Main.scala
@@ -1,0 +1,39 @@
+package com.gu.certificate
+
+import java.io.File
+
+
+object Main extends App {
+  case class Config(mode:String="", domain:String="", awsProfile:Option[String]=None, certificate:Option[File]=None, chain:Option[File]=None, force:Boolean=false, awsRegionName:Option[String]=None)
+
+  val parser = new scopt.OptionParser[Config]("magic") {
+    head("certificate magic", "1.0")
+    opt[String]('p', "profile") optional() action { (x, c) => c.copy(awsProfile = Some(x)) }
+    opt[String]('r', "region") optional() action { (x, c) => c.copy(awsRegionName = Some(x)) }
+    cmd("create") action { (_, c) =>
+      c.copy(mode = "create") } text "create a new keypair and certificate signing request (CSR)" children(
+        opt[String]('d', "domain") required() action { (x, c) => c.copy(domain = x) },
+        opt[Unit]('f', "force") optional() action { (_, c) => c.copy(force = true) }
+      )
+    cmd("install") action { (_, c) =>
+      c.copy(mode = "install") } text "install a certificate" children(
+      opt[File]("certificate") required() action { (x, c) =>
+        c.copy(certificate = Some(x)) } text "provided certificate",
+      opt[File]("chain") optional() action { (x, c) =>
+        c.copy(chain = Some(x)) } text "provided certificate chain (will try to build it if not provided)"
+      )
+    cmd("list") action { (_, c) => c.copy(mode = "list") }
+  }
+
+  parser.parse(args, Config()) foreach {
+    case Config("create", domain, profile, _, _, force, regionNameOpt) =>
+      Magic.create(domain, profile, force, regionNameOpt)
+
+    case Config("install", _, profile, Some(certificateFile), chainFile, _, regionNameOpt) =>
+      Magic.install(profile, certificateFile, chainFile, regionNameOpt)
+
+    case Config("list", _, _, _, _, _, _) =>
+      Magic.list()
+  }
+
+}


### PR DESCRIPTION
Entrypoint is now `Main`, which only does CLI parsing. `Magic` contains the business logic for the tool.

I recommend [using the ?w flag](https://github.com/guardian/certificate-magic/pull/3/files?w=1) when viewing the changes in this PR.
