### PR TITLE
Create an API GateWay domain name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.10.22",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.8",
   "org.bouncycastle" % "bcprov-jdk15on" % "1.52",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.52",
   "com.github.scopt" %% "scopt" % "3.3.0",

--- a/src/main/scala/com/gu/certificate/Magic.scala
+++ b/src/main/scala/com/gu/certificate/Magic.scala
@@ -6,6 +6,8 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProvider, STSAssumeRoleSessionCredentialsProvider, _}
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
+import com.amazonaws.services.apigateway.AmazonApiGatewayClient
+import com.amazonaws.services.apigateway.model.{CreateDomainNameRequest, TooManyRequestsException}
 import com.amazonaws.services.identitymanagement.model.{LimitExceededException, UploadServerCertificateRequest}
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
@@ -48,7 +50,7 @@ object Magic extends BouncyCastle with FileHelpers {
     System.err.println(s"Written encrypted PK to $pkEncFile and CSR to $csrFile")
   }
 
-  def install(keyProfile: Option[String], certificateFile: File, chainFile: Option[File], regionNameOpt: Option[String], installProfile:Option[String], path:Option[String]): Unit = {
+  def install(keyProfile: Option[String], certificateFile: File, chainFile: Option[File], regionNameOpt: Option[String], installProfile:Option[String], path:Option[String], service:Option[String]): Unit = {
     val region = getRegion(regionNameOpt)
     val keyCredentialsProvider = getCredentialsProvider(keyProfile)
     val installCredentialsProvider = installProfile.map(ip => getCredentialsProvider(Some(ip))).getOrElse(keyCredentialsProvider)
@@ -87,13 +89,22 @@ object Magic extends BouncyCastle with FileHelpers {
       getChainFromCertificate(certificate).map(toPem(_).trim).mkString("\n")
     }
 
-    System.err.println(s"installing to IAM")
-
     val pathPrefix = path.getOrElse("").stripPrefix("/").replace("/", "-")
+    val certificateName = s"$pathPrefix$safeDomain-exp$expDate"
+
+    service match {
+      case Some("iam") => installToIAM(path, region, installCredentialsProvider, certificateName, decryptedPem, certificatePem, chainPem)
+      case Some("apigateway") => installToGateway(region, installCredentialsProvider, safeDomain, certificateName, decryptedPem, certificatePem, chainPem)
+      case _ => None
+    }
+  }
+
+  def installToIAM (path: Option[String], region: Region, installCredentialsProvider: AWSCredentialsProvider, certificateName: String, decryptedPem: String, certificatePem: String, chainPem: String) {
+    System.err.println(s"installing to IAM")
 
     val iamClient = region.createClient(classOf[AmazonIdentityManagementClient], installCredentialsProvider, null)
     val certificateUploadRequest = new UploadServerCertificateRequest()
-      .withServerCertificateName(s"$pathPrefix$safeDomain-exp$expDate")
+      .withServerCertificateName(certificateName)
       .withPrivateKey(decryptedPem)
       .withCertificateBody(certificatePem)
       .withCertificateChain(chainPem)
@@ -106,6 +117,27 @@ object Magic extends BouncyCastle with FileHelpers {
     } recover {
       case e: LimitExceededException => System.err.println("You have reached the ServerCertificatesPerAccount limit for your account. Request more by opening a support ticket with AWS.")
       case e: Throwable => System.err.println(s"An error occurred during upload: ${e}")
+    }
+  }
+
+  def installToGateway (region: Region, installCredentialsProvider: AWSCredentialsProvider, safeDomain: String, certificateName: String, decryptedPem: String, certificatePem: String, chainPem: String): Unit = {
+    System.err.println(s"installing to API GateWay")
+
+    val client = region.createClient(classOf[AmazonApiGatewayClient], installCredentialsProvider, null)
+    val createDomainNameRequest = new CreateDomainNameRequest()
+      .withDomainName(safeDomain)
+      .withCertificateName(certificateName)
+      .withCertificateBody(certificatePem)
+      .withCertificatePrivateKey(decryptedPem)
+      .withCertificateChain(chainPem)
+
+    Try {
+      val createDomainNameResult = client.createDomainName(createDomainNameRequest)
+      val distributionDomainName = createDomainNameResult.getDistributionDomainName
+      System.err.println(s"successfully created an API GateWay domain name as $distributionDomainName")
+    } recover {
+      case e: TooManyRequestsException => System.err.println(s"You have reached the create domain name limit for your account. Retry in ${e.getRetryAfterSeconds} seconds.")
+      case e: Throwable => System.err.println(s"An error occurred during domain name creation: $e")
     }
   }
 


### PR DESCRIPTION
I've updated aws-sdk dependency because `1.10` doesn't have API GateWay.

The code is a bit rubbish, but that's the best I can do with scala
